### PR TITLE
lru-k policy

### DIFF
--- a/src/buffer/lru_k_replacer.cpp
+++ b/src/buffer/lru_k_replacer.cpp
@@ -11,19 +11,104 @@
 //===----------------------------------------------------------------------===//
 
 #include "buffer/lru_k_replacer.h"
+#include "common/exception.h"
 
 namespace bustub {
 
 LRUKReplacer::LRUKReplacer(size_t num_frames, size_t k) : replacer_size_(num_frames), k_(k) {}
 
-auto LRUKReplacer::Evict(frame_id_t *frame_id) -> bool { return false; }
+auto LRUKReplacer::Evict(frame_id_t *frame_id) -> bool {
+  std::scoped_lock<std::mutex> lock(latch_);
+  if (curr_size_ <= 0) {
+    return false;
+  }
+  bool seen_less_than_k = false;
+  bool seen_evictable = false;
+  frame_id_t candidate;
+  size_t min_ts;
+  for (auto &[id, cur_frame] : frames_) {
+    if (!cur_frame.evictable_) {
+      continue;
+    }
+    if (cur_frame.history_.empty()) {
+      candidate = id;
+      break;
+    }
+    auto cur_earliest_ts = *cur_frame.history_.begin();
+    if (cur_frame.history_.size() < k_) {
+      if (!seen_less_than_k || cur_earliest_ts < min_ts) {
+        candidate = id;
+        min_ts = cur_earliest_ts;
+        seen_less_than_k = true;
+      }
+    } else if (!seen_less_than_k && (!seen_evictable || cur_earliest_ts < min_ts)) {
+      candidate = id;
+      min_ts = cur_earliest_ts;
+    }
+    seen_evictable = true;
+  }
+  BUSTUB_ASSERT(seen_evictable, "curr_size_ greater than 0 but cannot find evictable frame");
+  frames_.erase(frames_.find(candidate));
+  curr_size_--;
+  *frame_id = candidate;
+  return true;
+}
 
-void LRUKReplacer::RecordAccess(frame_id_t frame_id) {}
+void LRUKReplacer::RecordAccess(frame_id_t frame_id) {
+  std::scoped_lock<std::mutex> lock(latch_);
+  PreCheck(frame_id);
+  current_timestamp_++;
+  auto it = frames_.find(frame_id);
+  if (it == frames_.end()) {
+    //    frames_.insert(std::make_pair(frame_id, FrameMeta{frame_id}));
+    frames_.emplace(frame_id, FrameMeta{frame_id});
+    it = frames_.find(frame_id);
+  }
+  //  bug: fail to update the object inside the container??
+  auto &frame = it->second;
+  frame.history_.emplace_back(current_timestamp_);
+  if (frame.history_.size() > k_) {
+    frame.history_.erase(it->second.history_.begin());
+  }
+}
 
-void LRUKReplacer::SetEvictable(frame_id_t frame_id, bool set_evictable) {}
+void LRUKReplacer::SetEvictable(frame_id_t frame_id, bool set_evictable) {
+  std::scoped_lock<std::mutex> lock(latch_);
+  PreCheck(frame_id);
+  auto iter = frames_.find(frame_id);
+  if (iter == frames_.end()) {
+    return;
+  }
+  auto &frame = iter->second;
+  if (set_evictable && !frame.evictable_) {
+    curr_size_++;
+  } else if (!set_evictable && frame.evictable_) {
+    curr_size_--;
+  }
+  frame.evictable_ = set_evictable;
+}
 
-void LRUKReplacer::Remove(frame_id_t frame_id) {}
+void LRUKReplacer::Remove(frame_id_t frame_id) {
+  std::scoped_lock<std::mutex> lock(latch_);
+  PreCheck(frame_id);
+  auto iter = frames_.find(frame_id);
+  if (iter == frames_.end()) {
+    return;
+  }
+  auto &frame = iter->second;
+  if (!frame.evictable_) {
+    throw Exception("remove non evitable frame is not allowed");
+  }
+  frames_.erase(iter);
+  curr_size_--;
+}
 
-auto LRUKReplacer::Size() -> size_t { return 0; }
+auto LRUKReplacer::Size() -> size_t { return curr_size_; }
+
+void LRUKReplacer::PreCheck(frame_id_t frame_id) {
+  if (frame_id < 0 || static_cast<size_t>(frame_id) >= replacer_size_) {
+    throw Exception("invalid frame_id");
+  }
+}
 
 }  // namespace bustub

--- a/src/include/buffer/lru_k_replacer.h
+++ b/src/include/buffer/lru_k_replacer.h
@@ -14,8 +14,10 @@
 
 #include <limits>
 #include <list>
+#include <map>
 #include <mutex>  // NOLINT
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common/config.h"
@@ -132,14 +134,26 @@ class LRUKReplacer {
    */
   auto Size() -> size_t;
 
+  struct FrameMeta {
+    explicit FrameMeta(frame_id_t id) : id_(id) {}
+    bool evictable_{false};
+    frame_id_t id_;
+    // increasing order, at most k records
+    std::list<std::size_t> history_;
+  };
+
  private:
   // TODO(student): implement me! You can replace these member variables as you like.
   // Remove maybe_unused if you start using them.
-  [[maybe_unused]] size_t current_timestamp_{0};
-  [[maybe_unused]] size_t curr_size_{0};
-  [[maybe_unused]] size_t replacer_size_;
-  [[maybe_unused]] size_t k_;
+  size_t current_timestamp_{0};
+  size_t curr_size_{0};
+  size_t replacer_size_;
+  size_t k_;
   std::mutex latch_;
+  std::unordered_map<frame_id_t, FrameMeta> frames_;
+
+  // no thread safe
+  void PreCheck(frame_id_t frame_id);
 };
 
 }  // namespace bustub

--- a/test/buffer/lru_k_replacer_test.cpp
+++ b/test/buffer/lru_k_replacer_test.cpp
@@ -16,7 +16,7 @@
 
 namespace bustub {
 
-TEST(LRUKReplacerTest, DISABLED_SampleTest) {
+TEST(LRUKReplacerTest, SampleTest) {
   LRUKReplacer lru_replacer(7, 2);
 
   // Scenario: add six elements to the replacer. We have [1,2,3,4,5]. Frame 6 is non-evictable.


### PR DESCRIPTION
Find evict table using brute force O(n) one pass search. We can use tree map to record the mapping from the timestamp of the last k access to the frameMeta, the evict search will take O(logn) whereas the time complexity of other function will increase to O(logn).

```
 make lru_k_replacer_test -j$(nproc)
 ./test/lru_k_replacer_test --gtest_break_on_failure
```
reuslt
```
[  PASSED  ] 1 test.
```