### PR TITLE
bufferpool

### DIFF
--- a/src/buffer/buffer_pool_manager.cpp
+++ b/src/buffer/buffer_pool_manager.cpp
@@ -14,6 +14,7 @@
 
 #include "common/exception.h"
 #include "common/macros.h"
+#include "fmt/format.h"
 #include "storage/page/page_guard.h"
 
 namespace bustub {
@@ -21,11 +22,6 @@ namespace bustub {
 BufferPoolManager::BufferPoolManager(size_t pool_size, DiskManager *disk_manager, size_t replacer_k,
                                      LogManager *log_manager)
     : pool_size_(pool_size), disk_manager_(disk_manager), log_manager_(log_manager) {
-  // TODO(students): remove this line after you have implemented the buffer pool manager
-  throw NotImplementedException(
-      "BufferPoolManager is not implemented yet. If you have finished implementing BPM, please remove the throw "
-      "exception line in `buffer_pool_manager.cpp`.");
-
   // we allocate a consecutive memory space for the buffer pool
   pages_ = new Page[pool_size_];
   replacer_ = std::make_unique<LRUKReplacer>(pool_size, replacer_k);
@@ -38,21 +34,84 @@ BufferPoolManager::BufferPoolManager(size_t pool_size, DiskManager *disk_manager
 
 BufferPoolManager::~BufferPoolManager() { delete[] pages_; }
 
-auto BufferPoolManager::NewPage(page_id_t *page_id) -> Page * { return nullptr; }
+auto BufferPoolManager::NewPage(page_id_t *page_id) -> Page * {
+  std::scoped_lock<std::mutex> lock(latch_);
+  auto page = GetAvailablePageAndInit([&]() { return this->AllocatePage(); });
+  if (page != nullptr) {
+    *page_id = page->page_id_;
+  }
+  return page;
+}
 
 auto BufferPoolManager::FetchPage(page_id_t page_id, [[maybe_unused]] AccessType access_type) -> Page * {
-  return nullptr;
+  std::scoped_lock<std::mutex> lock(latch_);
+  auto iter = page_table_.find(page_id);
+  if (iter != page_table_.end()) {
+    auto fid = iter->second;
+    replacer_->RecordAccess(fid);
+    replacer_->SetEvictable(fid, false);
+    auto page = &pages_[fid];
+    page->pin_count_++;
+    return page;
+  }
+  auto page = GetAvailablePageAndInit([page_id = page_id]() { return page_id; }, access_type);
+  if (page != nullptr) {
+    disk_manager_->ReadPage(page_id, page->GetData());
+  }
+  return page;
 }
 
 auto BufferPoolManager::UnpinPage(page_id_t page_id, bool is_dirty, [[maybe_unused]] AccessType access_type) -> bool {
-  return false;
+  std::scoped_lock<std::mutex> lock(latch_);
+  auto iter = page_table_.find(page_id);
+  if (iter == page_table_.end()) {
+    return false;
+  }
+  auto fid = iter->second;
+  auto page = &pages_[fid];
+  page->is_dirty_ = page->is_dirty_ || is_dirty;
+  if (page->pin_count_ <= 0) {
+    return false;
+  }
+  if (--page->pin_count_ == 0) {
+    replacer_->SetEvictable(fid, true);
+  }
+  return true;
 }
 
-auto BufferPoolManager::FlushPage(page_id_t page_id) -> bool { return false; }
+auto BufferPoolManager::FlushPage(page_id_t page_id) -> bool {
+  std::scoped_lock<std::mutex> lock(latch_);
+  return FlushPageInternal(page_id);
+}
 
-void BufferPoolManager::FlushAllPages() {}
+void BufferPoolManager::FlushAllPages() {
+  std::scoped_lock<std::mutex> lock(latch_);
+  for (size_t frame_id = 0; frame_id < pool_size_; frame_id++) {
+    FlushPageInternal(pages_[frame_id].page_id_);
+  }
+}
 
-auto BufferPoolManager::DeletePage(page_id_t page_id) -> bool { return false; }
+auto BufferPoolManager::DeletePage(page_id_t page_id) -> bool {
+  std::scoped_lock<std::mutex> lock(latch_);
+  auto iter = page_table_.find(page_id);
+  if (iter == page_table_.end()) {
+    return true;
+  }
+  auto fid = iter->second;
+  auto page = &pages_[fid];
+  if (page->pin_count_ > 0) {
+    return false;
+  }
+  replacer_->Remove(fid);
+  free_list_.emplace_back(fid);
+  page_table_.erase(iter);
+  page->ResetMemory();
+  page->pin_count_ = 0;
+  page->is_dirty_ = false;
+  page->page_id_ = INVALID_PAGE_ID;
+  DeallocatePage(page_id);
+  return true;
+}
 
 auto BufferPoolManager::AllocatePage() -> page_id_t { return next_page_id_++; }
 
@@ -63,5 +122,47 @@ auto BufferPoolManager::FetchPageRead(page_id_t page_id) -> ReadPageGuard { retu
 auto BufferPoolManager::FetchPageWrite(page_id_t page_id) -> WritePageGuard { return {this, nullptr}; }
 
 auto BufferPoolManager::NewPageGuarded(page_id_t *page_id) -> BasicPageGuard { return {this, nullptr}; }
+
+// not thread safe
+auto BufferPoolManager::GetAvailablePageAndInit(const std::function<page_id_t()> &page_id_generator,
+                                                AccessType access_type) -> Page * {
+  frame_id_t fid;
+  Page *page;
+  if (!free_list_.empty()) {
+    fid = free_list_.front();
+    free_list_.erase(free_list_.begin());
+    page = &pages_[fid];
+  } else {
+    auto evict = replacer_->Evict(&fid);
+    if (!evict) {
+      return nullptr;
+    }
+    page = &pages_[fid];
+    if (page->IsDirty()) {
+      disk_manager_->WritePage(page->page_id_, page->GetData());
+    }
+    page->is_dirty_ = false;
+    page->ResetMemory();
+    page_table_.erase(page->page_id_);
+  }
+  auto page_id = page_id_generator();
+  page_table_.emplace(page_id, fid);
+  page->page_id_ = page_id;
+  page->pin_count_ = 1;
+  replacer_->RecordAccess(fid, access_type);
+  // recorde access init the lrunode with evictable =false;
+  // replacer_->SetEvictable(fid, false);
+  return page;
+}
+
+auto BufferPoolManager::FlushPageInternal(page_id_t page_id) -> bool {
+  if (page_table_.find(page_id) == page_table_.end()) {
+    return false;
+  }
+  auto page = &pages_[page_table_[page_id]];
+  disk_manager_->WritePage(page_id, page->GetData());
+  page->is_dirty_ = false;
+  return true;
+}
 
 }  // namespace bustub

--- a/src/buffer/lru_k_replacer.cpp
+++ b/src/buffer/lru_k_replacer.cpp
@@ -64,7 +64,6 @@ void LRUKReplacer::RecordAccess(frame_id_t frame_id, [[maybe_unused]] AccessType
     node_store_.emplace(frame_id, LRUKNode{frame_id});
     it = node_store_.find(frame_id);
   }
-  //  bug: fail to update the object inside the container??
   auto &frame = it->second;
   frame.history_.emplace_back(current_timestamp_);
   if (frame.history_.size() > k_) {

--- a/src/include/buffer/buffer_pool_manager.h
+++ b/src/include/buffer/buffer_pool_manager.h
@@ -208,5 +208,9 @@ class BufferPoolManager {
   }
 
   // TODO(student): You may add additional private members and helper functions
+  auto GetAvailablePageAndInit(const std::function<page_id_t()> &page_id_generator,
+                               AccessType access_type = AccessType::Unknown) -> Page *;
+
+  auto FlushPageInternal(page_id_t page_id) -> bool;
 };
 }  // namespace bustub

--- a/test/buffer/buffer_pool_manager_test.cpp
+++ b/test/buffer/buffer_pool_manager_test.cpp
@@ -22,14 +22,14 @@ namespace bustub {
 
 // NOLINTNEXTLINE
 // Check whether pages containing terminal characters can be recovered
-TEST(BufferPoolManagerTest, DISABLED_BinaryDataTest) {
+TEST(BufferPoolManagerTest, BinaryDataTest) {
   const std::string db_name = "test.db";
   const size_t buffer_pool_size = 10;
   const size_t k = 5;
 
   std::random_device r;
   std::default_random_engine rng(r());
-  std::uniform_int_distribution<char> uniform_dist(0);
+  std::uniform_int_distribution<int8_t> uniform_dist(0);
 
   auto *disk_manager = new DiskManager(db_name);
   auto *bpm = new BufferPoolManager(buffer_pool_size, disk_manager, k);
@@ -88,7 +88,7 @@ TEST(BufferPoolManagerTest, DISABLED_BinaryDataTest) {
 }
 
 // NOLINTNEXTLINE
-TEST(BufferPoolManagerTest, DISABLED_SampleTest) {
+TEST(BufferPoolManagerTest, SampleTest) {
   const std::string db_name = "test.db";
   const size_t buffer_pool_size = 10;
   const size_t k = 5;


### PR DESCRIPTION
FetchPage: don't forget to increase the pin count and set evictable to false if page_id in page_table_
NewPage and FetchPage can share a common function to get available frame from either the free list or lru replacer; the lru replacer need to write the old page back to disk if it's dirty; regardless of the dirty state, always reset memory, reset dirty state and delete the old page_id from page_table.

NewPage need to allocate a page after finding an available frame whereas FetchPage doesn't need to do that. Abstract their different behavior as a function. Use const & when pass in the function.

FetchPage need additional step to read from disk.
