### PR TITLE
bptree insert and point search

### DIFF
--- a/src/include/storage/index/b_plus_tree.h
+++ b/src/include/storage/index/b_plus_tree.h
@@ -54,9 +54,12 @@ class Context {
   std::deque<ReadPageGuard> read_set_;
 
   auto IsRootPage(page_id_t page_id) -> bool { return page_id == root_page_id_; }
+  virtual ~Context();
 };
 
 #define BPLUSTREE_TYPE BPlusTree<KeyType, ValueType, KeyComparator>
+
+enum class ModificationType { INSERT = 0, DELETE };
 
 // Main class providing the API for the Interactive B+ Tree.
 INDEX_TEMPLATE_ARGUMENTS
@@ -129,6 +132,14 @@ class BPlusTree {
    * @return PrintableNode
    */
   auto ToPrintableBPlusTree(page_id_t root_id) -> PrintableBPlusTree;
+
+  // Acquire and release write latches as searching downwards along the way
+  auto FindLeafToModify(const KeyType &key, Context &ctx, ModificationType ops,
+                        const std::function<bool(BPlusTreePage *)> &safe) -> page_id_t;
+
+  void InsertToParent(page_id_t left_page_id, page_id_t right_page_id, const KeyType &key, Context &ctx);
+
+  void SetRootPage(page_id_t root_page_id, Context &ctx);
 
   // member variable
   std::string index_name_;

--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -73,6 +73,28 @@ class BPlusTreeInternalPage : public BPlusTreePage {
    */
   auto ValueAt(int index) const -> ValueType;
 
+  void Insert(const KeyType &key, const ValueType &value, const KeyComparator &keyComparator);
+
+  void InsertFirstValue(const ValueType &value);
+
+  void InsertAt(int index, const KeyType &key, const ValueType &value);
+
+  void MoveRightToHalf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient);
+
+  void MoveFirstToLastOf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient);
+
+  void MoveLastToFirstOf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient);
+
+  auto EraseAt(int index) -> MappingType;
+
+  /**
+   *
+   * @param key
+   * @param comparator
+   * @return The index of last key s.t. <= input key
+   */
+  auto Lookup(const KeyType &key, const KeyComparator &comparator) const -> int;
+
   /**
    * @brief For test only, return a string representing all keys in
    * this internal page, formatted as "(key1,key2,key3,...)"

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -60,6 +60,17 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   auto KeyAt(int index) const -> KeyType;
 
   /**
+   *
+   * @param key
+   * @param comparator
+   * @return the index of first key >= given key; if equal, return true
+   */
+  auto Lookup(const KeyType &key, const KeyComparator &comparator) const -> std::pair<int, bool>;
+  auto ValueAt(int index) const -> ValueType;
+  auto Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator) -> bool;
+  void MoveRightHalfTo(B_PLUS_TREE_LEAF_PAGE_TYPE *recipient);
+
+  /**
    * @brief for test only return a string representing all keys in
    * this leaf page formatted as "(key1,key2,key3,...)"
    *

--- a/src/storage/page/b_plus_tree_internal_page.cpp
+++ b/src/storage/page/b_plus_tree_internal_page.cpp
@@ -24,7 +24,11 @@ namespace bustub {
  * Including set page type, set current size, and set max page size
  */
 INDEX_TEMPLATE_ARGUMENTS
-void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Init(int max_size) {}
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Init(int max_size) {
+  SetPageType(IndexPageType::INTERNAL_PAGE);
+  SetSize(0);
+  SetMaxSize(max_size);
+}
 /*
  * Helper method to get/set the key associated with input "index"(a.k.a
  * array offset)
@@ -32,19 +36,112 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Init(int max_size) {}
 INDEX_TEMPLATE_ARGUMENTS
 auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::KeyAt(int index) const -> KeyType {
   // replace with your own code
-  KeyType key{};
-  return key;
+  if (index < 0 || index >= GetSize()) {
+    return KeyType{};
+  }
+  return array_[index].first;
 }
 
 INDEX_TEMPLATE_ARGUMENTS
-void B_PLUS_TREE_INTERNAL_PAGE_TYPE::SetKeyAt(int index, const KeyType &key) {}
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::SetKeyAt(int index, const KeyType &key) {
+  if (index < 0 || index >= GetSize()) {
+    return;
+  }
+  array_[index].first = key;
+}
 
 /*
  * Helper method to get the value associated with input "index"(a.k.a array
  * offset)
  */
 INDEX_TEMPLATE_ARGUMENTS
-auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const -> ValueType { return 0; }
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::ValueAt(int index) const -> ValueType {
+  if (index < 0 || index >= GetSize()) {
+    return ValueType{};
+  }
+  return array_[index].second;
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::Insert(const KeyType &key, const ValueType &value,
+                                            const KeyComparator &keyComparator) {
+  assert(GetSize() < GetMaxSize());
+  int insert_pos = Lookup(key, keyComparator) + 1;
+  assert(insert_pos > 0);
+  InsertAt(insert_pos, key, value);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::InsertAt(int index, const KeyType &key, const ValueType &value) {
+  assert(index >= 0 && index <= GetSize() && index < GetMaxSize());
+  for (int i = GetSize(); i > index; i--) {
+    std::swap(array_[i], array_[i - 1]);
+  }
+  array_[index] = std::make_pair(key, value);
+  IncreaseSize(1);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::InsertFirstValue(const ValueType &value) {
+  assert(GetSize() == 0);
+  array_[0] = std::make_pair(KeyType{}, value);
+  IncreaseSize(1);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveRightToHalf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient) {
+  int n = GetSize();
+  int mid = n / 2;
+  for (int i = mid, j = 0; i < n; i++, j++) {
+    std::swap(array_[i], recipient->array_[j]);
+  }
+  recipient->IncreaseSize(n - mid);
+  IncreaseSize(-(n - mid));
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::Lookup(const KeyType &key, const KeyComparator &keyComparator) const -> int {
+  int left = 1;
+  int right = GetSize() - 1;
+  while (left <= right) {
+    int mid = (right - left) / 2 + left;
+    if (keyComparator(array_[mid].first, key) <= 0) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+  return right;
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveFirstToLastOf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient) {
+  recipient->array_[recipient->GetSize()] = EraseAt(0);
+  recipient->IncreaseSize(1);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveLastToFirstOf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient) {
+  MappingType tmp = EraseAt(GetSize() - 1);
+  for (int i = recipient->GetSize(); i > 0; i--) {
+    std::swap(recipient->array_[i], recipient->array_[i - 1]);
+  }
+  recipient->array_[0] = tmp;
+  recipient->IncreaseSize(1);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::EraseAt(int index) -> MappingType {
+  if (index < 0 || index >= GetSize()) {
+    return std::make_pair(KeyType{}, ValueType{});
+  }
+  MappingType tmp = array_[index];
+  for (int i = index + 1; i < GetSize(); i++) {
+    std::swap(array_[i - 1], array_[i]);
+  }
+  IncreaseSize(-1);
+  return tmp;
+}
 
 // valuetype for internalNode should be page id_t
 template class BPlusTreeInternalPage<GenericKey<4>, page_id_t, GenericComparator<4>>;

--- a/src/storage/page/b_plus_tree_leaf_page.cpp
+++ b/src/storage/page/b_plus_tree_leaf_page.cpp
@@ -26,16 +26,21 @@ namespace bustub {
  * Including set page type, set current size to zero, set next page id and set max size
  */
 INDEX_TEMPLATE_ARGUMENTS
-void B_PLUS_TREE_LEAF_PAGE_TYPE::Init(int max_size) {}
+void B_PLUS_TREE_LEAF_PAGE_TYPE::Init(int max_size) {
+  SetPageType(IndexPageType::LEAF_PAGE);
+  SetSize(0);
+  SetMaxSize(max_size);
+  SetNextPageId(INVALID_PAGE_ID);
+}
 
 /**
  * Helper methods to set/get next page id
  */
 INDEX_TEMPLATE_ARGUMENTS
-auto B_PLUS_TREE_LEAF_PAGE_TYPE::GetNextPageId() const -> page_id_t { return INVALID_PAGE_ID; }
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::GetNextPageId() const -> page_id_t { return next_page_id_; }
 
 INDEX_TEMPLATE_ARGUMENTS
-void B_PLUS_TREE_LEAF_PAGE_TYPE::SetNextPageId(page_id_t next_page_id) {}
+void B_PLUS_TREE_LEAF_PAGE_TYPE::SetNextPageId(page_id_t next_page_id) { next_page_id_ = next_page_id; }
 
 /*
  * Helper method to find and return the key associated with input "index"(a.k.a
@@ -43,9 +48,60 @@ void B_PLUS_TREE_LEAF_PAGE_TYPE::SetNextPageId(page_id_t next_page_id) {}
  */
 INDEX_TEMPLATE_ARGUMENTS
 auto B_PLUS_TREE_LEAF_PAGE_TYPE::KeyAt(int index) const -> KeyType {
-  // replace with your own code
-  KeyType key{};
-  return key;
+  if (index < 0 || index >= GetSize()) {
+    return KeyType{};
+  }
+  return array_[index].first;
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::Lookup(const KeyType &key, const KeyComparator &comparator) const
+    -> std::pair<int, bool> {
+  int left = 0;
+  int right = GetSize() - 1;
+  while (left <= right) {
+    int mid = (right - left) / 2 + left;
+    if (comparator(array_[mid].first, key) >= 0) {
+      right = mid - 1;
+    } else {
+      left = mid + 1;
+    }
+  }
+  return std::make_pair(left, left >= GetSize() ? false : comparator(array_[left].first, key) == 0);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::ValueAt(int index) const -> ValueType {
+  if (index < 0 || index >= GetSize()) {
+    return ValueType{};
+  }
+  return array_[index].second;
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator)
+    -> bool {
+  auto [index, equal] = Lookup(key, comparator);
+  if (equal) {
+    return false;
+  }
+  for (int i = GetSize(); i > index; i--) {
+    std::swap(array_[i], array_[i - 1]);
+  }
+  array_[index] = std::make_pair(key, value);
+  IncreaseSize(1);
+  return true;
+}
+
+INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_LEAF_PAGE_TYPE::MoveRightHalfTo(B_PLUS_TREE_LEAF_PAGE_TYPE *recipient) {
+  int mid = GetSize() / 2;
+  int j = 0;
+  for (int i = mid; i < GetSize(); i++, j++) {
+    std::swap(array_[i], recipient->array_[j]);
+  }
+  IncreaseSize(-j);
+  recipient->IncreaseSize(j);
 }
 
 template class BPlusTreeLeafPage<GenericKey<4>, RID, GenericComparator<4>>;

--- a/src/storage/page/b_plus_tree_page.cpp
+++ b/src/storage/page/b_plus_tree_page.cpp
@@ -17,27 +17,27 @@ namespace bustub {
  * Helper methods to get/set page type
  * Page type enum class is defined in b_plus_tree_page.h
  */
-auto BPlusTreePage::IsLeafPage() const -> bool { return false; }
-void BPlusTreePage::SetPageType(IndexPageType page_type) {}
+auto BPlusTreePage::IsLeafPage() const -> bool { return page_type_ == IndexPageType::LEAF_PAGE; }
+void BPlusTreePage::SetPageType(IndexPageType page_type) { page_type_ = page_type; }
 
 /*
  * Helper methods to get/set size (number of key/value pairs stored in that
  * page)
  */
-auto BPlusTreePage::GetSize() const -> int { return 0; }
-void BPlusTreePage::SetSize(int size) {}
-void BPlusTreePage::IncreaseSize(int amount) {}
+auto BPlusTreePage::GetSize() const -> int { return size_; }
+void BPlusTreePage::SetSize(int size) { size_ = size; }
+void BPlusTreePage::IncreaseSize(int amount) { size_ += amount; }
 
 /*
  * Helper methods to get/set max size (capacity) of the page
  */
-auto BPlusTreePage::GetMaxSize() const -> int { return 0; }
-void BPlusTreePage::SetMaxSize(int size) {}
+auto BPlusTreePage::GetMaxSize() const -> int { return max_size_; }
+void BPlusTreePage::SetMaxSize(int size) { max_size_ = size; }
 
 /*
  * Helper method to get min page size
  * Generally, min page size == max page size / 2
  */
-auto BPlusTreePage::GetMinSize() const -> int { return 0; }
+auto BPlusTreePage::GetMinSize() const -> int { return IsLeafPage() ? max_size_ / 2 : (max_size_ + 1) / 2; }
 
 }  // namespace bustub

--- a/test/storage/b_plus_tree_insert_test.cpp
+++ b/test/storage/b_plus_tree_insert_test.cpp
@@ -23,7 +23,7 @@ namespace bustub {
 
 using bustub::DiskManagerUnlimitedMemory;
 
-TEST(BPlusTreeTests, DISABLED_InsertTest1) {
+TEST(BPlusTreeTests, InsertTest1) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
@@ -62,7 +62,7 @@ TEST(BPlusTreeTests, DISABLED_InsertTest1) {
   delete bpm;
 }
 
-TEST(BPlusTreeTests, DISABLED_InsertTest2) {
+TEST(BPlusTreeTests, InsertTest2) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());

--- a/test/storage/b_plus_tree_sequential_scale_test.cpp
+++ b/test/storage/b_plus_tree_sequential_scale_test.cpp
@@ -27,7 +27,7 @@ using bustub::DiskManagerUnlimitedMemory;
 /**
  * This test should be passing with your Checkpoint 1 submission.
  */
-TEST(BPlusTreeTests, DISABLED_ScaleTest) {  // NOLINT
+TEST(BPlusTreeTests, ScaleTest) {  // NOLINT
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());


### PR DESCRIPTION
Complete the checkpoint#1

Leverage b_plus_tree_printer for debugging. One of the input file for insertion test below. Compare the bptree shape of [course standard implementation](https://15445.courses.cs.cmu.edu/spring2023/bpt-printer/) and my-tree.dot rendered in this [website](http://dreampuf.github.io/GraphvizOnline/)

```
5
7
25
31
39
40
43
45
22
23
33
35
36
37
```

