### PR TITLE
bptree delete

### DIFF
--- a/src/include/storage/index/b_plus_tree.h
+++ b/src/include/storage/index/b_plus_tree.h
@@ -140,6 +140,25 @@ class BPlusTree {
   void InsertToParent(page_id_t left_page_id, page_id_t right_page_id, const KeyType &key, Context &ctx);
 
   void SetRootPage(page_id_t root_page_id, Context &ctx);
+  void DeleteRootPage(page_id_t page_id, Context &ctx);
+
+  void RemoveLeaf(page_id_t page_id, const KeyType &key, Context &ctx);
+
+  /**
+   * remove the page.array_[entry_index]
+   * @param parent_page_id
+   * @param entry_index
+   * @param ctx
+   */
+  void RemoveInternal(page_id_t page_id, int entry_index, Context &ctx);
+
+  /**
+   *
+   * @param parent_page
+   * @param key
+   * @return sibling page_id, isLeftSibling, the index of last key in the parent node s.t. <= the input key
+   */
+  auto GetSiblingPage(InternalPage *parent_page, const KeyType &key) -> std::tuple<page_id_t, bool, int>;
 
   // member variable
   std::string index_name_;

--- a/src/include/storage/page/b_plus_tree_internal_page.h
+++ b/src/include/storage/page/b_plus_tree_internal_page.h
@@ -87,6 +87,8 @@ class BPlusTreeInternalPage : public BPlusTreePage {
 
   auto EraseAt(int index) -> MappingType;
 
+  void MoveAllToEndOf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient);
+
   /**
    *
    * @param key

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -68,7 +68,13 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   auto Lookup(const KeyType &key, const KeyComparator &comparator) const -> std::pair<int, bool>;
   auto ValueAt(int index) const -> ValueType;
   auto Insert(const KeyType &key, const ValueType &value, const KeyComparator &comparator) -> bool;
+  auto Remove(const KeyType &key, const KeyComparator &comparator) -> bool;
   void MoveRightHalfTo(B_PLUS_TREE_LEAF_PAGE_TYPE *recipient);
+
+  void MoveLastToFirstOf(B_PLUS_TREE_LEAF_PAGE_TYPE *recipient);
+  void MoveFirstToLastOf(B_PLUS_TREE_LEAF_PAGE_TYPE *recipient);
+  void MoveAllToEndOf(B_PLUS_TREE_LEAF_PAGE_TYPE *recipient);
+  auto EraseAt(int index) -> MappingType;
 
   /**
    * @brief for test only return a string representing all keys in

--- a/src/storage/page/b_plus_tree_internal_page.cpp
+++ b/src/storage/page/b_plus_tree_internal_page.cpp
@@ -131,6 +131,17 @@ void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveLastToFirstOf(B_PLUS_TREE_INTERNAL_PAGE
 }
 
 INDEX_TEMPLATE_ARGUMENTS
+void B_PLUS_TREE_INTERNAL_PAGE_TYPE::MoveAllToEndOf(B_PLUS_TREE_INTERNAL_PAGE_TYPE *recipient) {
+  auto i = 0;
+  auto j = recipient->GetSize();
+  for (; i < GetSize(); i++, j++) {
+    std::swap(recipient->array_[j], array_[i]);
+  }
+  recipient->IncreaseSize(i);
+  IncreaseSize(-i);
+}
+
+INDEX_TEMPLATE_ARGUMENTS
 auto B_PLUS_TREE_INTERNAL_PAGE_TYPE::EraseAt(int index) -> MappingType {
   if (index < 0 || index >= GetSize()) {
     return std::make_pair(KeyType{}, ValueType{});

--- a/test/storage/b_plus_tree_delete_test.cpp
+++ b/test/storage/b_plus_tree_delete_test.cpp
@@ -23,7 +23,7 @@ namespace bustub {
 
 using bustub::DiskManagerUnlimitedMemory;
 
-TEST(BPlusTreeTests, DISABLED_DeleteTest1) {
+TEST(BPlusTreeTests, DeleteTest1) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
@@ -90,7 +90,7 @@ TEST(BPlusTreeTests, DISABLED_DeleteTest1) {
   delete bpm;
 }
 
-TEST(BPlusTreeTests, DISABLED_DeleteTest2) {
+TEST(BPlusTreeTests, DeleteTest2) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());


### PR DESCRIPTION
As the observation from website, the leaf max page size >=2, internal max page size>=3. 

After insertion on the leaf page, if the size == MaxSize(), the leaf page needs to be split. Thus, the max size you see in the browser is always = MaxSize()-1.

Leaf: MinSize = MaxSize/2; Internal: MaxSize = (MaxSize+1)/2;

 Internal: MaxSize = (MaxSize+1)/2 with internal max page size>=3 => The Internal Page should always contains at least two entries.

```
cd build
make b_plus_tree_printer -j$(nproc)
./bin/b_plus_tree_printer
> 4 4
> f delete_test_insert.txt
> c delete_test_delete.txt
> g my-tree.dot
```
Ensure graphs in the following two website are identical:
(1) Course standard implementation: https://15445.courses.cs.cmu.edu/spring2023/bpt-printer/
(2) Paste my-tree.dot on the website: http://dreampuf.github.io/GraphvizOnline

delete_test_insert.txt
```
5
7
25
31
39
40
43
45
22
23
33
35
36
32
```

delete_test_delete.txt
```
23
22
7
32
39
40
45
```

leaf=2, internal=3
delete_test2_insert.txt
```
5
25
50
75
10
```

delete_test2_delete.txt
```
75
25
```