### PR TITLE
bptree iterator; concurrent index; grade scope score 97.5

### DIFF
--- a/src/buffer/buffer_pool_manager.cpp
+++ b/src/buffer/buffer_pool_manager.cpp
@@ -115,19 +115,42 @@ auto BufferPoolManager::DeletePage(page_id_t page_id) -> bool {
 
 auto BufferPoolManager::AllocatePage() -> page_id_t { return next_page_id_++; }
 
-auto BufferPoolManager::FetchPageBasic(page_id_t page_id) -> BasicPageGuard { return {this, FetchPage(page_id)}; }
+auto BufferPoolManager::FetchPageBasic(page_id_t page_id) -> BasicPageGuard {
+  auto page = FetchPage(page_id);
+  if (page == nullptr) {
+    throw std::runtime_error("fail to fetch page");
+  }
+  return {this, FetchPage(page_id)};
+}
 
 auto BufferPoolManager::FetchPageRead(page_id_t page_id) -> ReadPageGuard {
   auto page = FetchPage(page_id);
+  if (page == nullptr) {
+    throw std::runtime_error("fail to fetch page");
+  }
   page->RLatch();
   return {this, page};
 }
 
 auto BufferPoolManager::FetchPageWrite(page_id_t page_id) -> WritePageGuard {
   auto page = FetchPage(page_id);
+  if (page == nullptr) {
+    throw std::runtime_error("fail to fetch page");
+  }
   page->WLatch();
   return {this, page};
 }
+
+// auto BufferPoolManager::FetchPageScan(page_id_t page_id) -> ReadPageGuard {
+//   auto page = FetchPage(page_id);
+//   if (page == nullptr) {
+//     throw std::runtime_error("fail to fetch page");
+//   }
+//   if (!page->TryRLatch()) {
+//     throw std::runtime_error("fail to get read latch on the sibling page");
+//   }
+//   return {this, page};
+// }
 
 auto BufferPoolManager::NewPageGuarded(page_id_t *page_id) -> BasicPageGuard { return {this, NewPage(page_id)}; }
 

--- a/src/include/buffer/buffer_pool_manager.h
+++ b/src/include/buffer/buffer_pool_manager.h
@@ -120,6 +120,7 @@ class BufferPoolManager {
   auto FetchPageBasic(page_id_t page_id) -> BasicPageGuard;
   auto FetchPageRead(page_id_t page_id) -> ReadPageGuard;
   auto FetchPageWrite(page_id_t page_id) -> WritePageGuard;
+  //  auto FetchPageScan(page_id_t page_id) -> ReadPageGuard;
 
   /**
    * TODO(P1): Add implementation

--- a/src/include/common/rwlatch.h
+++ b/src/include/common/rwlatch.h
@@ -44,6 +44,8 @@ class ReaderWriterLatch {
    */
   void RUnlock() { mutex_.unlock_shared(); }
 
+  auto TryRLock() -> bool { return mutex_.try_lock_shared(); }
+
  private:
   std::shared_mutex mutex_;
 };

--- a/src/include/storage/index/b_plus_tree.h
+++ b/src/include/storage/index/b_plus_tree.h
@@ -17,6 +17,7 @@
 #include <queue>
 #include <shared_mutex>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "common/config.h"
@@ -159,6 +160,8 @@ class BPlusTree {
    * @return sibling page_id, isLeftSibling, the index of last key in the parent node s.t. <= the input key
    */
   auto GetSiblingPage(InternalPage *parent_page, const KeyType &key) -> std::tuple<page_id_t, bool, int>;
+
+  auto FindLeafToRead(const KeyType &key, bool left_most, Context &ctx) -> page_id_t;
 
   // member variable
   std::string index_name_;

--- a/src/include/storage/index/index_iterator.h
+++ b/src/include/storage/index/index_iterator.h
@@ -21,9 +21,13 @@ namespace bustub {
 
 INDEX_TEMPLATE_ARGUMENTS
 class IndexIterator {
+  using LeafPage = BPlusTreeLeafPage<KeyType, ValueType, KeyComparator>;
+
  public:
   // you may define your own constructor based on your member variables
   IndexIterator();
+  IndexIterator(page_id_t page_id, int index, std::optional<ReadPageGuard> read_page_guard,
+                BufferPoolManager *buffer_pool_manager);
   ~IndexIterator();  // NOLINT
 
   auto IsEnd() -> bool;
@@ -32,12 +36,17 @@ class IndexIterator {
 
   auto operator++() -> IndexIterator &;
 
-  auto operator==(const IndexIterator &itr) const -> bool { throw std::runtime_error("unimplemented"); }
+  auto operator==(const IndexIterator &itr) const -> bool { return page_id_ == itr.page_id_ && index_ == itr.index_; }
 
-  auto operator!=(const IndexIterator &itr) const -> bool { throw std::runtime_error("unimplemented"); }
+  auto operator!=(const IndexIterator &itr) const -> bool { return page_id_ != itr.page_id_ || index_ != itr.index_; }
 
  private:
   // add your own private member variables here
+  page_id_t page_id_{INVALID_PAGE_ID};
+  int index_{-1};
+  std::optional<ReadPageGuard> page_guard_{std::nullopt};
+  BufferPoolManager *bpm_;
+  const LeafPage *page_;
 };
 
 }  // namespace bustub

--- a/src/include/storage/page/b_plus_tree_leaf_page.h
+++ b/src/include/storage/page/b_plus_tree_leaf_page.h
@@ -58,6 +58,7 @@ class BPlusTreeLeafPage : public BPlusTreePage {
   auto GetNextPageId() const -> page_id_t;
   void SetNextPageId(page_id_t next_page_id);
   auto KeyAt(int index) const -> KeyType;
+  auto ItemAt(int index) const -> const MappingType &;
 
   /**
    *

--- a/src/include/storage/page/page.h
+++ b/src/include/storage/page/page.h
@@ -63,6 +63,8 @@ class Page {
   /** Release the page read latch. */
   inline void RUnlatch() { rwlatch_.RUnlock(); }
 
+  inline auto TryRLatch() -> bool { return rwlatch_.TryRLock(); }
+
   /** @return the page LSN. */
   inline auto GetLSN() -> lsn_t { return *reinterpret_cast<lsn_t *>(GetData() + OFFSET_LSN); }
 

--- a/src/storage/index/index_iterator.cpp
+++ b/src/storage/index/index_iterator.cpp
@@ -7,24 +7,61 @@
 
 namespace bustub {
 
+INDEX_TEMPLATE_ARGUMENTS
+INDEXITERATOR_TYPE::IndexIterator() = default;
+
 /*
  * NOTE: you can change the destructor/constructor method here
  * set your own input parameters
  */
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE::IndexIterator() = default;
+INDEXITERATOR_TYPE::IndexIterator(page_id_t page_id, int index, std::optional<ReadPageGuard> read_page_guard,
+                                  BufferPoolManager *buffer_pool_manager)
+    : page_id_(page_id), index_(index), page_guard_(std::move(read_page_guard)), bpm_(buffer_pool_manager) {
+  if (page_id != INVALID_PAGE_ID) {
+    assert(page_guard_.has_value());
+    page_ = page_guard_.value().template As<LeafPage>();
+  }
+}
 
 INDEX_TEMPLATE_ARGUMENTS
-INDEXITERATOR_TYPE::~IndexIterator() = default;  // NOLINT
+INDEXITERATOR_TYPE::~IndexIterator() { page_guard_.reset(); };  // NOLINT
 
 INDEX_TEMPLATE_ARGUMENTS
-auto INDEXITERATOR_TYPE::IsEnd() -> bool { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::IsEnd() -> bool { return page_id_ == INVALID_PAGE_ID; }
 
 INDEX_TEMPLATE_ARGUMENTS
-auto INDEXITERATOR_TYPE::operator*() -> const MappingType & { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::operator*() -> const MappingType & {
+  assert(!IsEnd());
+  assert(page_ != nullptr);
+  return page_->ItemAt(index_);
+}
 
 INDEX_TEMPLATE_ARGUMENTS
-auto INDEXITERATOR_TYPE::operator++() -> INDEXITERATOR_TYPE & { throw std::runtime_error("unimplemented"); }
+auto INDEXITERATOR_TYPE::operator++() -> INDEXITERATOR_TYPE & {
+  if (IsEnd()) {
+    return *this;
+  }
+  if (index_ < page_->GetSize() - 1) {
+    index_++;
+    return *this;
+  }
+  auto next_page_id = page_->GetNextPageId();
+  if (next_page_id == INVALID_PAGE_ID) {
+    page_guard_.reset();
+    page_id_ = INVALID_PAGE_ID;
+    page_ = nullptr;
+    index_ = -1;
+    return *this;
+  }
+  //  auto next_page_guard = bpm_->FetchPageScan(next_page_id);
+  auto next_page_guard = bpm_->FetchPageRead(next_page_id);
+  page_guard_ = std::move(next_page_guard);
+  page_id_ = next_page_id;
+  page_ = page_guard_.value().template As<LeafPage>();
+  index_ = 0;
+  return *this;
+}
 
 template class IndexIterator<GenericKey<4>, RID, GenericComparator<4>>;
 

--- a/src/storage/page/b_plus_tree_leaf_page.cpp
+++ b/src/storage/page/b_plus_tree_leaf_page.cpp
@@ -157,6 +157,12 @@ auto B_PLUS_TREE_LEAF_PAGE_TYPE::EraseAt(int index) -> MappingType {
   return tmp;
 }
 
+INDEX_TEMPLATE_ARGUMENTS
+auto B_PLUS_TREE_LEAF_PAGE_TYPE::ItemAt(int index) const -> const MappingType & {
+  assert(index >= 0 || index < GetSize());
+  return array_[index];
+}
+
 template class BPlusTreeLeafPage<GenericKey<4>, RID, GenericComparator<4>>;
 template class BPlusTreeLeafPage<GenericKey<8>, RID, GenericComparator<8>>;
 template class BPlusTreeLeafPage<GenericKey<16>, RID, GenericComparator<16>>;

--- a/test/storage/b_plus_tree_concurrent_test.cpp
+++ b/test/storage/b_plus_tree_concurrent_test.cpp
@@ -122,8 +122,8 @@ void LookupHelper(BPlusTree<GenericKey<8>, RID, GenericComparator<8>> *tree, con
   delete transaction;
 }
 
-TEST(BPlusTreeConcurrentTest, DISABLED_InsertTest1) {
-  // create KeyComparator and index schema
+TEST(BPlusTreeConcurrentTest, InsertTest1) {
+  // create KeyComparator and index sche
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
 
@@ -170,7 +170,7 @@ TEST(BPlusTreeConcurrentTest, DISABLED_InsertTest1) {
   delete bpm;
 }
 
-TEST(BPlusTreeConcurrentTest, DISABLED_InsertTest2) {
+TEST(BPlusTreeConcurrentTest, InsertTest2) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
@@ -217,7 +217,7 @@ TEST(BPlusTreeConcurrentTest, DISABLED_InsertTest2) {
   delete bpm;
 }
 
-TEST(BPlusTreeConcurrentTest, DISABLED_DeleteTest1) {
+TEST(BPlusTreeConcurrentTest, DeleteTest1) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
@@ -256,7 +256,7 @@ TEST(BPlusTreeConcurrentTest, DISABLED_DeleteTest1) {
   delete bpm;
 }
 
-TEST(BPlusTreeConcurrentTest, DISABLED_DeleteTest2) {
+TEST(BPlusTreeConcurrentTest, DeleteTest2) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
@@ -295,7 +295,7 @@ TEST(BPlusTreeConcurrentTest, DISABLED_DeleteTest2) {
   delete bpm;
 }
 
-TEST(BPlusTreeConcurrentTest, DISABLED_MixTest1) {
+TEST(BPlusTreeConcurrentTest, MixTest1) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());
@@ -336,7 +336,7 @@ TEST(BPlusTreeConcurrentTest, DISABLED_MixTest1) {
   delete bpm;
 }
 
-TEST(BPlusTreeConcurrentTest, DISABLED_MixTest2) {
+TEST(BPlusTreeConcurrentTest, MixTest2) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());

--- a/test/storage/b_plus_tree_insert_test.cpp
+++ b/test/storage/b_plus_tree_insert_test.cpp
@@ -120,7 +120,7 @@ TEST(BPlusTreeTests, InsertTest2) {
   delete bpm;
 }
 
-TEST(BPlusTreeTests, DISABLED_InsertTest3) {
+TEST(BPlusTreeTests, InsertTest3) {
   // create KeyComparator and index schema
   auto key_schema = ParseCreateStatement("a bigint");
   GenericComparator<8> comparator(key_schema.get());


### PR DESCRIPTION
Use PageWrite/ReadGuard at the beginning of p2, so there's no special change I need to modify for insert and delete. In order to avoid the deadlock problem between delete and leaf scan, I invoked the std::shared_mutex.try_lock_shared() via the bpm->FetchPageScan() and successfully pass the local test. However, the grade scope doesn't seem to pickup the Page and ReaderWriterLatch class. Thus I go back to the FetchPageRead method.

Fail to pass an insert test.
 
![bptree1](https://i.imgur.com/zR8Ekhr.png)
![bptree2](https://i.imgur.com/yYevf4I.png)

Write QPS: 11772.11
Read QPS: 200931.36
