### PR TITLE
Tweak latch crabbing for insertion

### DIFF
--- a/src/buffer/buffer_pool_manager.cpp
+++ b/src/buffer/buffer_pool_manager.cpp
@@ -120,7 +120,7 @@ auto BufferPoolManager::FetchPageBasic(page_id_t page_id) -> BasicPageGuard {
   if (page == nullptr) {
     throw std::runtime_error("fail to fetch page");
   }
-  return {this, FetchPage(page_id)};
+  return {this, page};
 }
 
 auto BufferPoolManager::FetchPageRead(page_id_t page_id) -> ReadPageGuard {
@@ -152,7 +152,13 @@ auto BufferPoolManager::FetchPageWrite(page_id_t page_id) -> WritePageGuard {
 //   return {this, page};
 // }
 
-auto BufferPoolManager::NewPageGuarded(page_id_t *page_id) -> BasicPageGuard { return {this, NewPage(page_id)}; }
+auto BufferPoolManager::NewPageGuarded(page_id_t *page_id) -> BasicPageGuard {
+  auto page = NewPage(page_id);
+  if (page == nullptr) {
+    throw std::runtime_error("fail to fetch page");
+  }
+  return {this, page};
+}
 
 // not thread safe
 auto BufferPoolManager::GetAvailablePageAndInit(const std::function<page_id_t()> &page_id_generator,

--- a/src/include/storage/index/b_plus_tree.h
+++ b/src/include/storage/index/b_plus_tree.h
@@ -135,8 +135,7 @@ class BPlusTree {
   auto ToPrintableBPlusTree(page_id_t root_id) -> PrintableBPlusTree;
 
   // Acquire and release write latches as searching downwards along the way
-  auto FindLeafToModify(const KeyType &key, Context &ctx, ModificationType ops,
-                        const std::function<bool(BPlusTreePage *)> &safe) -> page_id_t;
+  auto FindLeafToModify(const KeyType &key, Context &ctx, ModificationType ops) -> page_id_t;
 
   void InsertToParent(page_id_t left_page_id, page_id_t right_page_id, const KeyType &key, Context &ctx);
 
@@ -162,6 +161,8 @@ class BPlusTree {
   auto GetSiblingPage(InternalPage *parent_page, const KeyType &key) -> std::tuple<page_id_t, bool, int>;
 
   auto FindLeafToRead(const KeyType &key, bool left_most, Context &ctx) -> page_id_t;
+
+  void ReleaseAncestors(Context &ctx);
 
   // member variable
   std::string index_name_;


### PR DESCRIPTION
- Fix an idiot bug in FetchBasicGuard
- Tweak the latch crabbing rule of insertion
   - For internal page, ancestor pages can be unlocked if size < maxSize;
   - For leaf page, ancestor pages can be unlocked if size+1 < maxSize.

Unfortunately, still fail on the same GradeScope test case.
