### PR TITLE
hash join; nest loop join; optimize nlj into hash join

### DIFF
--- a/src/execution/aggregation_executor.cpp
+++ b/src/execution/aggregation_executor.cpp
@@ -26,6 +26,7 @@ AggregationExecutor::AggregationExecutor(ExecutorContext *exec_ctx, const Aggreg
 
 void AggregationExecutor::Init() {
   child_->Init();
+  aht_.Clear();
   Tuple tuple;
   RID rid;
   while (child_->Next(&tuple, &rid)) {

--- a/src/execution/hash_join_executor.cpp
+++ b/src/execution/hash_join_executor.cpp
@@ -11,21 +11,116 @@
 //===----------------------------------------------------------------------===//
 
 #include "execution/executors/hash_join_executor.h"
+#include "common/util/hash_util.h"
+#include "type/value_factory.h"
 
 namespace bustub {
 
 HashJoinExecutor::HashJoinExecutor(ExecutorContext *exec_ctx, const HashJoinPlanNode *plan,
                                    std::unique_ptr<AbstractExecutor> &&left_child,
                                    std::unique_ptr<AbstractExecutor> &&right_child)
-    : AbstractExecutor(exec_ctx) {
+    : AbstractExecutor(exec_ctx),
+      plan_(plan),
+      left_executor_(std::move(left_child)),
+      right_executor_(std::move(right_child)) {
   if (!(plan->GetJoinType() == JoinType::LEFT || plan->GetJoinType() == JoinType::INNER)) {
     // Note for 2023 Spring: You ONLY need to implement left join and inner join.
     throw bustub::NotImplementedException(fmt::format("join type {} not supported", plan->GetJoinType()));
   }
 }
 
-void HashJoinExecutor::Init() { throw NotImplementedException("HashJoinExecutor is not implemented"); }
+void HashJoinExecutor::Init() {
+  ht_.clear();
+  right_executor_->Init();
+  Tuple tuple;
+  RID rid;
+  while (right_executor_->Next(&tuple, &rid)) {
+    const auto &right_key = GetRightJoinKey(&tuple);
+    auto iter = ht_.find(right_key);
+    if (iter == ht_.end()) {
+      ht_.emplace(right_key, std::vector<Tuple>{});
+      iter = ht_.find(right_key);
+    }
+    iter->second.emplace_back(tuple);
+  }
+  left_executor_->Init();
+  GetNextLeftTuple();
+}
 
-auto HashJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
+auto HashJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool {
+  if (left_end_) {
+    return false;
+  }
+  bool find_right = false;
+  while (!find_right && !left_end_) {
+    if (right_end_opt_.has_value()) {
+      auto right_end = right_end_opt_.value();
+      if (right_iter_ != right_end) {
+        find_right = true;
+        last_left_match_ = true;
+        auto right_tuple = *right_iter_;
+        ++right_iter_;
+        std::vector<Value> vals;
+        vals.reserve(left_executor_->GetOutputSchema().GetColumnCount() +
+                     right_executor_->GetOutputSchema().GetColumnCount());
+        for (auto i = 0U; i < left_executor_->GetOutputSchema().GetColumnCount(); i++) {
+          vals.emplace_back(left_tuple_.GetValue(&left_executor_->GetOutputSchema(), i));
+        }
+        for (auto i = 0U; i < right_executor_->GetOutputSchema().GetColumnCount(); i++) {
+          vals.emplace_back(right_tuple.GetValue(&right_executor_->GetOutputSchema(), i));
+        }
+        *tuple = Tuple{vals, &GetOutputSchema()};
+      }
+    }
+    if (!find_right && !last_left_match_ && plan_->GetJoinType() == JoinType::LEFT) {
+      find_right = true;
+      std::vector<Value> vals;
+      vals.reserve(left_executor_->GetOutputSchema().GetColumnCount() +
+                   right_executor_->GetOutputSchema().GetColumnCount());
+      for (auto i = 0U; i < left_executor_->GetOutputSchema().GetColumnCount(); i++) {
+        vals.emplace_back(left_tuple_.GetValue(&left_executor_->GetOutputSchema(), i));
+      }
+      for (auto i = 0U; i < right_executor_->GetOutputSchema().GetColumnCount(); i++) {
+        vals.emplace_back(ValueFactory::GetNullValueByType(right_executor_->GetOutputSchema().GetColumn(i).GetType()));
+      }
+      *tuple = Tuple{vals, &GetOutputSchema()};
+    }
+    if (!right_end_opt_.has_value() || right_iter_ == right_end_opt_.value()) {
+      GetNextLeftTuple();
+    }
+  }
+  return find_right;
+}
+
+auto HashJoinExecutor::GetLeftJoinKey(const Tuple *tuple) -> JoinKey {
+  return JoinKey{GetJoinKeys(tuple, left_executor_->GetOutputSchema(), plan_->LeftJoinKeyExpressions())};
+}
+
+auto HashJoinExecutor::GetRightJoinKey(const Tuple *tuple) -> JoinKey {
+  return JoinKey{GetJoinKeys(tuple, right_executor_->GetOutputSchema(), plan_->RightJoinKeyExpressions())};
+}
+
+auto HashJoinExecutor::GetJoinKeys(const Tuple *tuple, const Schema &schema,
+                                   const std::vector<AbstractExpressionRef> &expressions) const -> std::vector<Value> {
+  std::vector<Value> join_keys;
+  join_keys.reserve(expressions.size());
+  for (auto &expr : expressions) {
+    join_keys.emplace_back(expr->Evaluate(tuple, schema));
+  }
+  return join_keys;
+}
+
+void HashJoinExecutor::GetNextLeftTuple() {
+  last_left_match_ = false;
+  right_end_opt_.reset();
+  RID left_rid;
+  left_end_ = !left_executor_->Next(&left_tuple_, &left_rid);
+  if (!left_end_) {
+    if (auto iter = ht_.find(GetLeftJoinKey(&left_tuple_)); iter != ht_.end()) {
+      right_iter_ = iter->second.begin();
+      right_end_opt_ = iter->second.end();
+    }
+  }
+}
 
 }  // namespace bustub

--- a/src/execution/nested_loop_join_executor.cpp
+++ b/src/execution/nested_loop_join_executor.cpp
@@ -13,21 +13,83 @@
 #include "execution/executors/nested_loop_join_executor.h"
 #include "binder/table_ref/bound_join_ref.h"
 #include "common/exception.h"
+#include "type/value_factory.h"
 
 namespace bustub {
 
 NestedLoopJoinExecutor::NestedLoopJoinExecutor(ExecutorContext *exec_ctx, const NestedLoopJoinPlanNode *plan,
                                                std::unique_ptr<AbstractExecutor> &&left_executor,
                                                std::unique_ptr<AbstractExecutor> &&right_executor)
-    : AbstractExecutor(exec_ctx) {
+    : AbstractExecutor(exec_ctx),
+      plan_(plan),
+      left_executor_(std::move(left_executor)),
+      right_executor_(std::move(right_executor)) {
   if (!(plan->GetJoinType() == JoinType::LEFT || plan->GetJoinType() == JoinType::INNER)) {
     // Note for 2023 Spring: You ONLY need to implement left join and inner join.
     throw bustub::NotImplementedException(fmt::format("join type {} not supported", plan->GetJoinType()));
   }
 }
 
-void NestedLoopJoinExecutor::Init() { throw NotImplementedException("NestedLoopJoinExecutor is not implemented"); }
+void NestedLoopJoinExecutor::Init() {
+  left_executor_->Init();
+  RightExecutorInit();
+}
 
-auto NestedLoopJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool { return false; }
+auto NestedLoopJoinExecutor::Next(Tuple *tuple, RID *rid) -> bool {
+  if (left_end_) {
+    return false;
+  }
+  Tuple right_tuple;
+  RID right_id;
+  bool find_right = false;
+  while (!find_right && !left_end_) {
+    while (right_executor_->Next(&right_tuple, &right_id)) {
+      auto equal = plan_->Predicate()->EvaluateJoin(&left_tuple_, left_executor_->GetOutputSchema(), &right_tuple,
+                                                    right_executor_->GetOutputSchema());
+      if (equal.GetAs<bool>()) {
+        find_right = true;
+        last_left_match_ = true;
+        std::vector<Value> vals;
+        auto left_col_num = left_executor_->GetOutputSchema().GetColumnCount();
+        auto right_col_num = right_executor_->GetOutputSchema().GetColumnCount();
+        vals.reserve(left_col_num + right_col_num);
+        for (auto i = 0U; i < left_col_num; i++) {
+          vals.emplace_back(left_tuple_.GetValue(&left_executor_->GetOutputSchema(), i));
+        }
+        for (auto i = 0U; i < right_col_num; i++) {
+          vals.emplace_back(right_tuple.GetValue(&right_executor_->GetOutputSchema(), i));
+        }
+        *tuple = Tuple(vals, &GetOutputSchema());
+        return find_right;
+      }
+    }
+
+    if (plan_->GetJoinType() == JoinType::LEFT && !last_left_match_) {
+      find_right = true;
+      std::vector<Value> vals;
+      auto left_col_num = left_executor_->GetOutputSchema().GetColumnCount();
+      auto right_col_num = right_executor_->GetOutputSchema().GetColumnCount();
+      vals.reserve(left_col_num + right_col_num);
+      for (auto i = 0U; i < left_col_num; i++) {
+        vals.emplace_back(left_tuple_.GetValue(&left_executor_->GetOutputSchema(), i));
+      }
+      for (auto i = 0U; i < right_col_num; i++) {
+        vals.emplace_back(ValueFactory::GetNullValueByType(right_executor_->GetOutputSchema().GetColumn(i).GetType()));
+      }
+      *tuple = Tuple(vals, &GetOutputSchema());
+    }
+    RightExecutorInit();
+  }
+  return find_right;
+}
+
+void NestedLoopJoinExecutor::RightExecutorInit() {
+  last_left_match_ = false;
+  RID left_rid;
+  left_end_ = !left_executor_->Next(&left_tuple_, &left_rid);
+  if (!left_end_) {
+    right_executor_->Init();
+  }
+}
 
 }  // namespace bustub

--- a/src/execution/seq_scan_executor.cpp
+++ b/src/execution/seq_scan_executor.cpp
@@ -15,16 +15,16 @@
 namespace bustub {
 
 SeqScanExecutor::SeqScanExecutor(ExecutorContext *exec_ctx, const SeqScanPlanNode *plan)
-    : AbstractExecutor(exec_ctx),
-      plan_(plan),
-      iter_(exec_ctx_->GetCatalog()->GetTable(plan_->table_oid_)->table_->MakeIterator()) {}
+    : AbstractExecutor(exec_ctx), plan_(plan) {}
 
-void SeqScanExecutor::Init() {}
+void SeqScanExecutor::Init() {
+  iter_ = std::make_unique<TableIterator>(exec_ctx_->GetCatalog()->GetTable(plan_->table_oid_)->table_->MakeIterator());
+}
 
 auto SeqScanExecutor::Next(Tuple *tuple, RID *rid) -> bool {
-  while (!iter_.IsEnd()) {
-    auto [tuple_meta, cur_tuple] = iter_.GetTuple();
-    ++iter_;
+  while (!iter_->IsEnd()) {
+    auto [tuple_meta, cur_tuple] = iter_->GetTuple();
+    ++(*iter_);
     if (!tuple_meta.is_deleted_ &&
         (plan_->filter_predicate_ == nullptr ||
          plan_->filter_predicate_->Evaluate(&cur_tuple, plan_->OutputSchema()).GetAs<bool>())) {

--- a/src/include/execution/executors/hash_join_executor.h
+++ b/src/include/execution/executors/hash_join_executor.h
@@ -13,8 +13,11 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
+#include "common/util/hash_util.h"
 #include "execution/executor_context.h"
 #include "execution/executors/abstract_executor.h"
 #include "execution/plans/hash_join_plan.h"
@@ -22,6 +25,47 @@
 
 namespace bustub {
 
+/** JoinKey represents a key in an hash join operation */
+struct JoinKey {
+  /** The join keys */
+  std::vector<Value> keys_;
+
+  /**
+   * Compares two join key for equality.
+   * @param other the other join key to be compared with
+   * @return `true` if both join keys have equivalent expressions, `false` otherwise
+   */
+  auto operator==(const JoinKey &other) const -> bool {
+    BUSTUB_ASSERT(this->keys_.size() == other.keys_.size(), "join key size is not equal");
+    for (uint32_t i = 0; i < other.keys_.size(); i++) {
+      if (keys_[i].CompareEquals(other.keys_[i]) != CmpBool::CmpTrue) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+}  // namespace bustub
+
+namespace std {
+/** Implements std::hash on JoinKey */
+template <>
+struct hash<bustub::JoinKey> {
+  auto operator()(const bustub::JoinKey &join_key) const -> std::size_t {
+    size_t curr_hash = 0;
+    for (const auto &key : join_key.keys_) {
+      if (!key.IsNull()) {
+        curr_hash = bustub::HashUtil::CombineHashes(curr_hash, bustub::HashUtil::HashValue(&key));
+      }
+    }
+    return curr_hash;
+  }
+};
+
+}  // namespace std
+
+namespace bustub {
 /**
  * HashJoinExecutor executes a nested-loop JOIN on two tables.
  */
@@ -51,9 +95,25 @@ class HashJoinExecutor : public AbstractExecutor {
   /** @return The output schema for the join */
   auto GetOutputSchema() const -> const Schema & override { return plan_->OutputSchema(); };
 
+  auto GetLeftJoinKey(const Tuple *tuple) -> JoinKey;
+
+  auto GetRightJoinKey(const Tuple *tuple) -> JoinKey;
+
  private:
+  auto GetJoinKeys(const Tuple *tuple, const Schema &schema,
+                   const std::vector<AbstractExpressionRef> &expressions) const -> std::vector<Value>;
+  void GetNextLeftTuple();
+
   /** The NestedLoopJoin plan node to be executed. */
   const HashJoinPlanNode *plan_;
+  std::unique_ptr<AbstractExecutor> left_executor_;
+  std::unique_ptr<AbstractExecutor> right_executor_;
+  std::unordered_map<JoinKey, std::vector<Tuple>> ht_;
+  std::vector<Tuple>::iterator right_iter_;
+  std::optional<std::vector<Tuple>::iterator> right_end_opt_{std::nullopt};
+  Tuple left_tuple_;
+  bool left_end_{false};
+  bool last_left_match_{false};
 };
 
 }  // namespace bustub

--- a/src/include/execution/executors/nested_loop_join_executor.h
+++ b/src/include/execution/executors/nested_loop_join_executor.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "execution/executor_context.h"
 #include "execution/executors/abstract_executor.h"
@@ -52,9 +53,16 @@ class NestedLoopJoinExecutor : public AbstractExecutor {
   /** @return The output schema for the insert */
   auto GetOutputSchema() const -> const Schema & override { return plan_->OutputSchema(); };
 
+  void RightExecutorInit();
+
  private:
   /** The NestedLoopJoin plan node to be executed. */
   const NestedLoopJoinPlanNode *plan_;
+  std::unique_ptr<AbstractExecutor> left_executor_;
+  std::unique_ptr<AbstractExecutor> right_executor_;
+  bool left_end_{false};
+  bool last_left_match_{false};
+  Tuple left_tuple_;
 };
 
 }  // namespace bustub

--- a/src/include/execution/executors/seq_scan_executor.h
+++ b/src/include/execution/executors/seq_scan_executor.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "execution/executor_context.h"
@@ -50,6 +51,6 @@ class SeqScanExecutor : public AbstractExecutor {
  private:
   /** The sequential scan plan node to be executed */
   const SeqScanPlanNode *plan_;
-  TableIterator iter_;
+  std::unique_ptr<TableIterator> iter_;
 };
 }  // namespace bustub

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -10,6 +10,8 @@
 #include "catalog/catalog.h"
 #include "concurrency/transaction.h"
 #include "execution/expressions/abstract_expression.h"
+#include "execution/expressions/column_value_expression.h"
+#include "execution/expressions/comparison_expression.h"
 #include "execution/plans/abstract_plan.h"
 
 namespace bustub {
@@ -100,6 +102,12 @@ class Optimizer {
    * @return std::optional<size_t>
    */
   auto EstimatedCardinality(const std::string &table_name) -> std::optional<size_t>;
+
+  /**
+   * @brief if the expression is an equal comparison for column expr, copy column expressions by setting tuple id = 0
+   */
+  auto ExtractColExprForColEqualComparison(const ComparisonExpression *expr)
+      -> std::optional<std::pair<std::shared_ptr<ColumnValueExpression>, std::shared_ptr<ColumnValueExpression>>>;
 
   /** Catalog will be used during the planning process. USERS SHOULD ENSURE IT OUTLIVES
    * OPTIMIZER, otherwise it's a dangling reference.

--- a/src/optimizer/nlj_as_hash_join.cpp
+++ b/src/optimizer/nlj_as_hash_join.cpp
@@ -7,6 +7,7 @@
 #include "execution/expressions/column_value_expression.h"
 #include "execution/expressions/comparison_expression.h"
 #include "execution/expressions/constant_value_expression.h"
+#include "execution/expressions/logic_expression.h"
 #include "execution/plans/abstract_plan.h"
 #include "execution/plans/filter_plan.h"
 #include "execution/plans/hash_join_plan.h"
@@ -22,7 +23,73 @@ auto Optimizer::OptimizeNLJAsHashJoin(const AbstractPlanNodeRef &plan) -> Abstra
   // Note for 2023 Spring: You should at least support join keys of the form:
   // 1. <column expr> = <column expr>
   // 2. <column expr> = <column expr> AND <column expr> = <column expr>
-  return plan;
+  //
+  std::vector<AbstractPlanNodeRef> children;
+  for (const auto &child : plan->GetChildren()) {
+    children.emplace_back(OptimizeNLJAsHashJoin(child));
+  }
+  auto optimized_plan = plan->CloneWithChildren(std::move(children));
+
+  if (optimized_plan->GetType() != PlanType::NestedLoopJoin) {
+    return optimized_plan;
+  }
+  const auto &nlj_plan = dynamic_cast<const NestedLoopJoinPlanNode &>(*optimized_plan);
+  // Has exactly two children
+  BUSTUB_ENSURE(nlj_plan.children_.size() == 2, "NLJ should have exactly 2 children.");
+
+  // Check if expr is equal condition where one is for the left table, and one is for the right table.
+  if (const auto *expr = dynamic_cast<const ComparisonExpression *>(nlj_plan.Predicate().get()); expr != nullptr) {
+    auto res = ExtractColExprForColEqualComparison(expr);
+    if (res.has_value()) {
+      return std::make_shared<HashJoinPlanNode>(
+          nlj_plan.output_schema_, nlj_plan.GetLeftPlan(), nlj_plan.GetRightPlan(),
+          std::vector<AbstractExpressionRef>{std::move(res->first)},
+          std::vector<AbstractExpressionRef>{std::move(res->second)}, nlj_plan.GetJoinType());
+    }
+  }
+
+  if (const auto *expr = dynamic_cast<const LogicExpression *>(nlj_plan.Predicate().get());
+      expr != nullptr && expr->logic_type_ == LogicType::And) {
+    const auto *left_expr = dynamic_cast<const ComparisonExpression *>(expr->GetChildAt(0).get());
+    const auto *right_expr = dynamic_cast<const ComparisonExpression *>(expr->GetChildAt(1).get());
+    if (left_expr != nullptr && right_expr != nullptr) {
+      if (auto left_res = ExtractColExprForColEqualComparison(left_expr); left_res.has_value()) {
+        if (auto right_res = ExtractColExprForColEqualComparison(right_expr); right_res.has_value()) {
+          return std::make_shared<HashJoinPlanNode>(
+              nlj_plan.output_schema_, nlj_plan.GetLeftPlan(), nlj_plan.GetRightPlan(),
+              std::vector<AbstractExpressionRef>{std::move(left_res->first), std::move(right_res->first)},
+              std::vector<AbstractExpressionRef>{std::move(left_res->second), std::move(right_res->second)},
+              nlj_plan.GetJoinType());
+        }
+      }
+    }
+  }
+  return optimized_plan;
+}
+
+auto Optimizer::ExtractColExprForColEqualComparison(const ComparisonExpression *expr)
+    -> std::optional<std::pair<std::shared_ptr<ColumnValueExpression>, std::shared_ptr<ColumnValueExpression>>> {
+  if (expr->comp_type_ != ComparisonType::Equal) {
+    return std::nullopt;
+  }
+  if (const auto *left_expr = dynamic_cast<const ColumnValueExpression *>(expr->children_[0].get());
+      left_expr != nullptr) {
+    if (const auto *right_expr = dynamic_cast<const ColumnValueExpression *>(expr->children_[1].get());
+        right_expr != nullptr) {
+      // Ensure both exprs have tuple_id == 0
+      auto left_expr_tuple =
+          std::make_shared<ColumnValueExpression>(0, left_expr->GetColIdx(), left_expr->GetReturnType());
+      auto right_expr_tuple =
+          std::make_shared<ColumnValueExpression>(0, right_expr->GetColIdx(), right_expr->GetReturnType());
+      if (left_expr->GetTupleIdx() == 0 && right_expr->GetTupleIdx() == 1) {
+        return std::make_pair(std::move(left_expr_tuple), std::move(right_expr_tuple));
+      }
+      if (left_expr->GetTupleIdx() == 1 && right_expr->GetTupleIdx() == 0) {
+        return std::make_pair(std::move(right_expr_tuple), std::move(left_expr_tuple));
+      }
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace bustub


### PR DESCRIPTION
Fix the bug of Init() of Aggregation and SeqScan executor to ensure repeatable Init() get the same result. For nested loop join, remember to invoke right_executor.Init() each time you invoke the left.executor.Next(); number of right_executor.Init()+1 >= number of left_executor.Next(). The difference 1 comes from that you can skip right executor init wheb the left_executor Next() returns false.

pass all test from p3-01.slt to p3-15.slt except the NextedIndexJoin test which is out of scope of Spring 2023.